### PR TITLE
[Refactor] 카카오 로그인 지원을 위한 회원 엔티티 구조 변경 및 마이페이지 API 수정

### DIFF
--- a/src/main/java/com/example/weterview/controller/OAuthController.java
+++ b/src/main/java/com/example/weterview/controller/OAuthController.java
@@ -1,8 +1,8 @@
 package com.example.weterview.controller;
 
-import com.example.weterview.dto.SignupInfoDto;
+import com.example.weterview.dto.common.request.SignupInfoReq;
 import com.example.weterview.dto.common.ApiResponse;
-import com.example.weterview.dto.common.OurMemberDto;
+import com.example.weterview.dto.common.response.OurMemberDto;
 import com.example.weterview.service.OAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +31,7 @@ public class OAuthController {
     }
 
     @PostMapping("/signup")
-    public ApiResponse<?> signup(@RequestBody SignupInfoDto request) {
+    public ApiResponse<?> signup(@RequestBody SignupInfoReq request) {
         return oAuthService.signup(request);
     }
 }

--- a/src/main/java/com/example/weterview/dto/common/request/SignupInfoReq.java
+++ b/src/main/java/com/example/weterview/dto/common/request/SignupInfoReq.java
@@ -1,24 +1,22 @@
-package com.example.weterview.dto;
+package com.example.weterview.dto.common.request;
 
 import jakarta.validation.constraints.*;
 import lombok.*;
 
 @Data
 @NoArgsConstructor
-public class SignupInfoDto {
-    @NotBlank
+public class SignupInfoReq {
+    @NotBlank(message = "카카오 회원 번호는 필수 입니다.")
     private String kakaoUserNumber;
 
     @NotBlank
     @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,30}$", message = "Nickname must be 2 to 30 characters long and contain only Korean letters, English letters, or digits.")
     private String nickname;
 
-    @NotBlank
+    @NotBlank(message = "이메일을 필수 입니다.")
     @Email
-    private String email;
+    private String kakaoEmail;
 
-    @NotBlank
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+{}\\[\\]|\\\\;:'\",.<>/?]).{8,}$")
-    @Max(value = 100, message = "The password can be up to 100 digits")
-    private String password;
+    @NotBlank(message = "성별은 필수 입니다.")
+    private String gender;
 }

--- a/src/main/java/com/example/weterview/dto/common/response/NewUserKakaoInfoRes.java
+++ b/src/main/java/com/example/weterview/dto/common/response/NewUserKakaoInfoRes.java
@@ -1,4 +1,4 @@
-package com.example.weterview.dto.common;
+package com.example.weterview.dto.common.response;
 
 import lombok.*;
 

--- a/src/main/java/com/example/weterview/dto/common/response/OurMemberDto.java
+++ b/src/main/java/com/example/weterview/dto/common/response/OurMemberDto.java
@@ -1,4 +1,4 @@
-package com.example.weterview.dto.common;
+package com.example.weterview.dto.common.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/com/example/weterview/dto/common/response/PagiBasicDto.java
+++ b/src/main/java/com/example/weterview/dto/common/response/PagiBasicDto.java
@@ -1,4 +1,4 @@
-package com.example.weterview.dto.common;
+package com.example.weterview.dto.common.response;
 
 import jakarta.validation.constraints.Min;
 import lombok.Data;

--- a/src/main/java/com/example/weterview/dto/common/response/SignupRes.java
+++ b/src/main/java/com/example/weterview/dto/common/response/SignupRes.java
@@ -1,4 +1,4 @@
-package com.example.weterview.dto.common;
+package com.example.weterview.dto.common.response;
 
 import lombok.*;
 

--- a/src/main/java/com/example/weterview/dto/myPage/request/GetHostedStudyGroupReq.java
+++ b/src/main/java/com/example/weterview/dto/myPage/request/GetHostedStudyGroupReq.java
@@ -1,6 +1,6 @@
 package com.example.weterview.dto.myPage.request;
 
-import com.example.weterview.dto.common.PagiBasicDto;
+import com.example.weterview.dto.common.response.PagiBasicDto;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/src/main/java/com/example/weterview/dto/myPage/response/GetMyPageInfoRes.java
+++ b/src/main/java/com/example/weterview/dto/myPage/response/GetMyPageInfoRes.java
@@ -8,8 +8,7 @@ import java.time.LocalDateTime;
 public class GetMyPageInfoRes {
     private LocalDateTime createdAt;
     private LocalDateTime UpdatedAt;
-    private String email;
-    private String name;
+    private String kakaoEmail;
     private String nickname;
-    private byte[] profileImage;
+    private String gender;
 }

--- a/src/main/java/com/example/weterview/dto/studyGroup/request/GetStudyGroupReq.java
+++ b/src/main/java/com/example/weterview/dto/studyGroup/request/GetStudyGroupReq.java
@@ -1,6 +1,6 @@
 package com.example.weterview.dto.studyGroup.request;
 
-import com.example.weterview.dto.common.PagiBasicDto;
+import com.example.weterview.dto.common.response.PagiBasicDto;
 import com.example.weterview.enums.studyGroup.FieldEnum;
 import com.example.weterview.enums.studyGroup.LocationEnum;
 import com.example.weterview.enums.studyGroup.StatusEnum;

--- a/src/main/java/com/example/weterview/entity/User.java
+++ b/src/main/java/com/example/weterview/entity/User.java
@@ -20,16 +20,19 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(name = "kakao_user_number")
+    @Column(nullable = false, name = "kakao_user_number")
     private String kakaoUserNumber;
 
-    @Column(name = "nickname", length = 100)
+    @Column(nullable = false,name = "nickname", length = 100)
     private String nickname;
 
-    @Column(name = "kakao_email", length = 100)
-    private String email;
+    @Column(nullable = false,name = "kakao_email", length = 100)
+    private String kakaoEmail;
 
-    @Column(name = "created_at", updatable = false)
+    @Column(nullable = false, name = "gender")
+    private String gender;
+
+    @Column(nullable = false,name = "created_at", updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/weterview/service/MyPageService.java
+++ b/src/main/java/com/example/weterview/service/MyPageService.java
@@ -41,8 +41,9 @@ public class MyPageService {
         GetMyPageInfoRes getMyPageInfoRes = new GetMyPageInfoRes();
         getMyPageInfoRes.setCreatedAt(user.getCreatedAt());
         getMyPageInfoRes.setUpdatedAt(user.getUpdatedAt());
-        getMyPageInfoRes.setEmail(user.getEmail());
+        getMyPageInfoRes.setKakaoEmail(user.getKakaoEmail());
         getMyPageInfoRes.setNickname(user.getNickname());
+        getMyPageInfoRes.setGender(user.getGender());
 
         return ApiResponse.ok(getMyPageInfoRes, "사용자 정보 반환");
     }

--- a/src/main/java/com/example/weterview/service/OAuthService.java
+++ b/src/main/java/com/example/weterview/service/OAuthService.java
@@ -3,9 +3,10 @@ package com.example.weterview.service;
 import com.example.weterview.dto.*;
 import com.example.weterview.dto.common.ApiResponse;
 
-import com.example.weterview.dto.common.NewUserKakaoInfoRes;
-import com.example.weterview.dto.common.OurMemberDto;
-import com.example.weterview.dto.common.SignupRes;
+import com.example.weterview.dto.common.response.NewUserKakaoInfoRes;
+import com.example.weterview.dto.common.response.OurMemberDto;
+import com.example.weterview.dto.common.response.SignupRes;
+import com.example.weterview.dto.common.request.SignupInfoReq;
 import com.example.weterview.entity.User;
 import com.example.weterview.repository.UserRepository;
 import com.example.weterview.utils.JwtUtil;
@@ -167,19 +168,19 @@ public class OAuthService {
         // 즉, 직접 수행하는것이 아닌 외주를 맡긴다고 생각
     }
 
-    public ApiResponse<String> signup(SignupInfoDto userInfo) {
+    // 추가 정보 입력 -> 회원가입
+    public ApiResponse<String> signup(SignupInfoReq userInfo) {
         boolean isMember = userRepository.existsByKakaoUserNumber(userInfo.getKakaoUserNumber());
 
         if (isMember) {
             return ApiResponse.BAD_REQUEST(null, "이미 가입된 회원입니다. 로그인을 해주세요");
         } else {
-            String encodedPassword = pwEncoder.encode(userInfo.getPassword());
-
             User newUser = new User();
+
             newUser.setKakaoUserNumber(userInfo.getKakaoUserNumber());
             newUser.setNickname(userInfo.getNickname());
-            newUser.setEmail(userInfo.getEmail());
-            newUser.setPassword(encodedPassword);
+            newUser.setGender(userInfo.getGender());
+            newUser.setKakaoEmail(userInfo.getKakaoEmail());
 
             userRepository.save(newUser);
 


### PR DESCRIPTION
## 📌 개요 (Summary)
카카오 소셜 로그인 기능을 원활하게 지원하기 위해 기존 `users` 엔티티의 구조를 변경하고, 이에 맞춰 마이페이지 정보 조회 API 응답을 수정했습니다.

## 🛠 작업 내용 (Changes)
**1. 회원(users) 엔티티 구조 변경**
- **비밀번호 필드 삭제:** 소셜 로그인 전용으로 전환됨에 따라 기존 자체 로그인용 `password` 필드를 제거했습니다.
- **카카오 전용 필드 추가:** `kakaoEmail`, `kakaoUserNumbe`, `gender` 필드를 추가하여 카카오 사용자 정보를 저장하도록 했습니다.

**2. API 응답 수정 (마이페이지)**
- **내 정보 조회 API:** 응답 DTO에서 `email`을 `kakaoEmail`로 대체하고, `gender` 정보를 포함하도록 수정했습니다.
- 불필요해진 profileImage는 응답에서 제외했습니다.

**3. 기타 (Chore)**
- 프로젝트 구조 개선을 위해 일부 파일의 패키지 위치를 이동했습니다.