### PR TITLE
[Fix] studygroup create

### DIFF
--- a/src/main/java/com/example/weterview/controller/MyPageController.java
+++ b/src/main/java/com/example/weterview/controller/MyPageController.java
@@ -42,10 +42,10 @@ public class MyPageController {
     @GetMapping("/hosted-study-groups")
     public ApiResponse<List<GetHostedStudyGroupRes>> getHostedStudyGroups(
             @RequestHeader("Authorization") String jwt,
-            @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
+            @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
             @RequestParam(value = "pageSize", defaultValue = "10") int pageSize
     ) {
-        return myPageService.getHostedStudyGroups(jwt, pageNumber, pageSize);
+        return myPageService.getHostedStudyGroups(jwt, pageNumber - 1, pageSize);
     }
 
     // 내가 참여한 스터디 그룹 모집 게시글 조회

--- a/src/main/java/com/example/weterview/repository/StudyGroupRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupRepository.java
@@ -5,11 +5,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>,
         JpaSpecificationExecutor<StudyGroup> {
     Page<StudyGroup> findByUser(User user, Pageable pageable);
+    // Users 엔티티에서 kakaonum으로 user id 조회
+    // studygroupmembership에서 user id로 조회
+    // 조회한 게시글 id로 studygroup에서 조회
+    @Query("SELECT sg FROM StudyGroup sg WHERE sg.id = (SELECT s.studyGroup.id FROM StudyMembership s WHERE s.user.id = (SELECT u.id FROM User u WHERE u.kakaoUserNumber = :kakaoNum))")
+    Page<StudyGroup> findByKakaonum(@Param("kakaoNum") String kakaoNum, Pageable pageable);
 }
+
+
 

--- a/src/main/java/com/example/weterview/service/MyPageService.java
+++ b/src/main/java/com/example/weterview/service/MyPageService.java
@@ -62,14 +62,13 @@ public class MyPageService {
     }
 
     // 내가 개설한 스터디 그룹 모집 게시글 조회
-    public ApiResponse<List<GetHostedStudyGroupRes>> getHostedStudyGroups(String jwt, int pageNumber, int pageSize) {
+    public ApiResponse<List<GetHostedStudyGroupRes>> getHostedStudyGroups(
+            String jwt, int pageNumber, int pageSize) {
         String kakaoUniqueNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
-        User user = userRepository.findByKakaoUserNumber(kakaoUniqueNumber)
-                .orElseThrow(() -> new IllegalArgumentException("없는 사용자 입니다"));
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize,
-                Sort.by("createdAt").descending());
-        Page<StudyGroup> hostedStudyGroupPage = studyGroupRepository.findByUser(user, pageable);
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<StudyGroup> hostedStudyGroupPage = studyGroupRepository.findByKakaonum(kakaoUniqueNumber, pageable);
 
         // 정적 팩토리 메서드 방식
         Page<GetHostedStudyGroupRes> result = hostedStudyGroupPage.map(GetHostedStudyGroupRes::from);

--- a/src/main/java/com/example/weterview/service/StudyGroupService.java
+++ b/src/main/java/com/example/weterview/service/StudyGroupService.java
@@ -48,6 +48,7 @@ public class StudyGroupService {
                     .orElseThrow(() -> new IllegalArgumentException("username에 해당하는 사용자가 존재하지 않습니다."));
 
             StudyGroup studyGroup = new StudyGroup();
+            StudyMembership studyMembership = new StudyMembership();
 
             studyGroup.setUser(user);
             studyGroup.setField(req.getField());
@@ -64,6 +65,11 @@ public class StudyGroupService {
             studyGroup.setContact(req.getContact());
 
             studyGroupRepository.save(studyGroup);
+
+            studyMembership.setUser(user);
+            studyMembership.setStudyGroup(studyGroup);
+
+            studyMembershipRepository.save(studyMembership);
 
             return ApiResponse.ok(null, "스터디 그룹을 생성했습니다");
         } catch (Exception e) {


### PR DESCRIPTION
- 스터디 그룹 게시글 생성 시에 사용자, 스터디 그룹 게시글 연관관계를 StudyMembership 테이블에 저장하는 로직 추가
- 내가 개설한 스터디 그룹 게시글 조회 시에 kakaoUserNumber로 조회 후 반환