### PR TITLE
[REFAC] Controller에서 JWT에 있는 유저 정보 파싱 하는 기능 SecurityConfig로 위임

### DIFF
--- a/src/main/java/com/example/weterview/config/CustomUserDetails.java
+++ b/src/main/java/com/example/weterview/config/CustomUserDetails.java
@@ -1,0 +1,31 @@
+package com.example.weterview.config;
+
+import com.example.weterview.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() { return List.of(); }
+    @Override
+    public String getPassword() { return ""; }
+    @Override
+    public String getUsername() { return String.valueOf(user.getId()); }
+
+    public String getKakaoUserNumber() {
+        return user.getKakaoUserNumber();
+    }
+
+    public String getKakaoEmail() {
+        return user.getKakaoEmail();
+    }
+}

--- a/src/main/java/com/example/weterview/config/SecurityConfig.java
+++ b/src/main/java/com/example/weterview/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.weterview.config;
 
+import com.example.weterview.repository.UserRepository;
 import com.example.weterview.utils.JwtAuthenticationFilter;
 import com.example.weterview.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
 
     private static final String[] OAUTH_URL = {
@@ -44,7 +46,7 @@ public class SecurityConfig {
      */
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtUtil);
+        return new JwtAuthenticationFilter(userRepository, jwtUtil);
     }
 
     /**

--- a/src/main/java/com/example/weterview/utils/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/weterview/utils/JwtAuthenticationFilter.java
@@ -1,10 +1,14 @@
 package com.example.weterview.utils;
 
+import com.example.weterview.config.CustomUserDetails;
+import com.example.weterview.entity.User;
+import com.example.weterview.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -13,6 +17,7 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
 
     @Override
@@ -22,10 +27,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         String token = jwtUtil.resolveToken(request);
+
         if (token != null && jwtUtil.isTokenExpired(token)) {
-            Authentication auth = jwtUtil.createAuthentication(token);
+            String kakaoUserNumber = jwtUtil.getKakaoUserNumFromToken(token);
+
+            User user = userRepository.findByKakaoUserNumber(kakaoUserNumber)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+
+            CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+//            Authentication auth = jwtUtil.createAuthentication(token);
+
+            Authentication auth =
+                    new UsernamePasswordAuthenticationToken(
+                            customUserDetails,
+                            null,
+                            customUserDetails.getAuthorities());
+
             SecurityContextHolder.getContext().setAuthentication(auth);
         }
+
         // **반드시** 다음 필터로 요청을 넘겨줘야 함
         filterChain.doFilter(request, response);
     }


### PR DESCRIPTION
기존
- 사용자 정보를 controller, service단에서 사용하려면 header에 있는 jwt를 받아서 사용

개선
- controller, service에서 jwt를 해석 하는 과정을 SecurityConfig로 위임 -> 각 api 마다 jwt에서 값을 추출하여 사용하지 않아도 된다.