### PR TITLE
[FEAT] 게시글 like/unlike API 수정, JWT 파싱 로직 JwtFilter로 위임, 게시글 상세 조회 시에 좋아요 상태 추가

### DIFF
--- a/src/main/java/com/example/weterview/controller/StudyGroupController.java
+++ b/src/main/java/com/example/weterview/controller/StudyGroupController.java
@@ -1,12 +1,17 @@
 package com.example.weterview.controller;
 
+import com.example.weterview.config.CustomUserDetails;
 import com.example.weterview.dto.common.ApiResponse;
 import com.example.weterview.dto.studyGroup.request.*;
+import com.example.weterview.entity.User;
 import com.example.weterview.service.StudyGroupService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/studygroup")
 @RequiredArgsConstructor
@@ -29,8 +34,14 @@ public class StudyGroupController {
 
     // 스터디 그룹 모집 게시글 단건 조회
     @GetMapping("/get/{id}")
-    public ApiResponse<GetStudyGroupByIdRes> getStudyGroupById(@PathVariable String id) {
-        return studyGroupService.getStudyGroupById(id);
+    public ApiResponse<GetStudyGroupByIdRes> getStudyGroupById(
+            @PathVariable String id,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        User user = new User();
+        if (customUserDetails == null) {
+            user = null;
+        }
+        return studyGroupService.getStudyGroupById(id, user);
     }
 
     // 스터디 그룹 모집 게시글 수정
@@ -78,7 +89,7 @@ public class StudyGroupController {
     }
 
     // 스터디 그룹 모집 게시글 좋아요 취소
-    @DeleteMapping("/{studyGroupId}/likes")
+    @PostMapping("/{studyGroupId}/unlikes")
     public ApiResponse<?> unlikeStudyGroup(
             @PathVariable String studyGroupId,
             @RequestHeader("Authorization") String jwt){

--- a/src/main/java/com/example/weterview/dto/studyGroup/request/GetStudyGroupByIdRes.java
+++ b/src/main/java/com/example/weterview/dto/studyGroup/request/GetStudyGroupByIdRes.java
@@ -29,4 +29,5 @@ public class GetStudyGroupByIdRes {
     private String contact;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean isLiked;
 }

--- a/src/main/java/com/example/weterview/dto/studyGroup/request/GetStudyGroupByIdRes.java
+++ b/src/main/java/com/example/weterview/dto/studyGroup/request/GetStudyGroupByIdRes.java
@@ -3,6 +3,7 @@ package com.example.weterview.dto.studyGroup.request;
 import com.example.weterview.enums.studyGroup.FieldEnum;
 import com.example.weterview.enums.studyGroup.LocationEnum;
 import com.example.weterview.enums.studyGroup.StatusEnum;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,5 +30,6 @@ public class GetStudyGroupByIdRes {
     private String contact;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    @JsonProperty("isLiked")
     private boolean isLiked;
 }

--- a/src/main/java/com/example/weterview/entity/StudyGroupLike.java
+++ b/src/main/java/com/example/weterview/entity/StudyGroupLike.java
@@ -33,6 +33,6 @@ public class StudyGroupLike {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/weterview/entity/StudyGroupLike.java
+++ b/src/main/java/com/example/weterview/entity/StudyGroupLike.java
@@ -26,6 +26,9 @@ public class StudyGroupLike {
     @JoinColumn(name = "study_group_id")
     private StudyGroup studyGroup;
 
+    @Column(name = "is_liked")
+    private boolean isLiked;
+
     @Column(name = "created_at")
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/weterview/entity/StudyGroupLike.java
+++ b/src/main/java/com/example/weterview/entity/StudyGroupLike.java
@@ -27,7 +27,7 @@ public class StudyGroupLike {
     private StudyGroup studyGroup;
 
     @Column(name = "is_liked")
-    private boolean isLiked;
+    private boolean isLiked = false;
 
     @Column(name = "created_at")
     @CreatedDate

--- a/src/main/java/com/example/weterview/repository/StudyGroupRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>,
         JpaSpecificationExecutor<StudyGroup> {
@@ -16,7 +18,7 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>,
     // Users 엔티티에서 kakaonum으로 user id 조회
     // studygroupmembership에서 user id로 조회
     // 조회한 게시글 id로 studygroup에서 조회
-    @Query("SELECT sg FROM StudyGroup sg WHERE sg.id = (SELECT s.studyGroup.id FROM StudyMembership s WHERE s.user.id = (SELECT u.id FROM User u WHERE u.kakaoUserNumber = :kakaoNum))")
+    @Query("SELECT sg FROM StudyGroup sg WHERE sg.id IN (SELECT s.studyGroup.id FROM StudyMembership s WHERE s.user.id = (SELECT u.id FROM User u WHERE u.kakaoUserNumber = :kakaoNum))")
     Page<StudyGroup> findByKakaonum(@Param("kakaoNum") String kakaoNum, Pageable pageable);
 }
 

--- a/src/main/java/com/example/weterview/service/StudyGroupService.java
+++ b/src/main/java/com/example/weterview/service/StudyGroupService.java
@@ -102,9 +102,18 @@ public class StudyGroupService {
     }
 
     // 스터디 그룹 단일 조회
-    public ApiResponse<GetStudyGroupByIdRes> getStudyGroupById(String id) {
+    public ApiResponse<GetStudyGroupByIdRes> getStudyGroupById(String id, User user) {
         StudyGroup studyGroup = studyGroupRepository.findById(Long.parseLong(id))
                 .orElseThrow(() -> new IllegalArgumentException("없는 게시글 입니다."));
+
+        boolean isLiked = false;
+
+        if (user != null) {
+            Optional<StudyGroupLike> studyGroupLike = studyGroupLikeRepository.findByStudyGroupAndUser(studyGroup, user);
+            if (studyGroupLike.isPresent()) {
+                isLiked = studyGroupLike.get().isLiked();
+            }
+        }
 
         GetStudyGroupByIdRes getStudyGroupByIdRes = GetStudyGroupByIdRes.builder()
                 .id(studyGroup.getId().toString())
@@ -123,6 +132,7 @@ public class StudyGroupService {
                 .contact(studyGroup.getContact())
                 .createdAt(studyGroup.getCreatedAt())
                 .updatedAt(studyGroup.getUpdatedAt())
+                .isLiked(isLiked)
                 .build();
 
         return ApiResponse.ok(getStudyGroupByIdRes, "조회성공");
@@ -232,7 +242,7 @@ public class StudyGroupService {
         return ApiResponse.ok(result, "댓글 조회 성공");
     }
 
-    // 좋아요
+    // 게시글 좋아요
     public ApiResponse<?> likeStudyGroup(String studyGroupId, String jwt) {
         String kakaoUserNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
 
@@ -241,16 +251,23 @@ public class StudyGroupService {
         StudyGroup studyGroup = studyGroupRepository.findById(Long.parseLong(studyGroupId))
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글 입니다."));
 
-        StudyGroupLike studyGroupLike = new StudyGroupLike();
-        studyGroupLike.setUser(user);
-        studyGroupLike.setStudyGroup(studyGroup);
+        Optional<StudyGroupLike> studyGroupLike = studyGroupLikeRepository.findByStudyGroupAndUser(studyGroup, user);
 
-        studyGroupLikeRepository.save(studyGroupLike);
+        if (studyGroupLike.isPresent()) {
+            studyGroupLike.get().setLiked(true);
+            studyGroupLikeRepository.save(studyGroupLike.get());
+        } else {
+            StudyGroupLike like = new StudyGroupLike();
+            like.setUser(user);
+            like.setStudyGroup(studyGroup);
+            like.setLiked(true);
+            studyGroupLikeRepository.save(like);
+        }
 
         return ApiResponse.ok(null, "좋아요 성공");
     }
 
-    // Soft Delete로 구현
+    // 게시글 좋아요 취소
     public ApiResponse<?> unlikeStudyGroup(String studyGroupId, String jwt) {
         String kakaoUserNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
 
@@ -262,7 +279,8 @@ public class StudyGroupService {
         StudyGroupLike studyGroupLike = studyGroupLikeRepository.findByStudyGroupAndUser(studyGroup, user)
                 .orElseThrow(() -> new IllegalArgumentException("없는 게시글입니다."));
 
-        studyGroupLike.setDeletedAt(LocalDateTime.now());
+        studyGroupLike.setUpdatedAt(LocalDateTime.now());
+        studyGroupLike.setLiked(false);
         studyGroupLikeRepository.save(studyGroupLike);
 
         return ApiResponse.ok(null, "좋이요 취소 성공");

--- a/src/main/java/com/example/weterview/utils/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/weterview/utils/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,6 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final UserRepository userRepository;
@@ -35,8 +37,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
 
             CustomUserDetails customUserDetails = new CustomUserDetails(user);
-
-//            Authentication auth = jwtUtil.createAuthentication(token);
 
             Authentication auth =
                     new UsernamePasswordAuthenticationToken(


### PR DESCRIPTION
### JWT 파싱 로직 JwtFilter로 위임
#### 기존
- service 단에서 JWT에 있는 사용자 정보를 사용하기 위해서는 Controller에서 Header로 JWT를 받아 service 단에서 사용자 정보를 추출하여 사용해야 했다.

#### 현재
- Filter에서 JWT에 있는 사용자 정보를 추출하여 DB 조회 후에 Controller에서 CustomUserDetails 클래스에서 가져와서 사용 가능하도록 변경

#### 비회원/회원
- 게시글 상세조회 좋아요 상태