### PR TITLE
[FEAT/REFAC] 전역 예외처리 추가 및 mypage 관련 API 코드 리팩토링

### DIFF
--- a/src/main/java/com/example/weterview/controller/MyPageController.java
+++ b/src/main/java/com/example/weterview/controller/MyPageController.java
@@ -3,9 +3,8 @@ package com.example.weterview.controller;
 import com.example.weterview.config.CustomUserDetails;
 import com.example.weterview.dto.common.ApiResponse;
 import com.example.weterview.dto.myPage.request.UpdateNicknameReq;
-import com.example.weterview.dto.myPage.response.GetHostedStudyGroupRes;
-import com.example.weterview.dto.myPage.response.GetJoinedStudyGroupRes;
-import com.example.weterview.dto.myPage.response.MyPageRes;
+import com.example.weterview.dto.myPage.response.*;
+import com.example.weterview.dto.studyGroup.response.GetStudyGroupApplyMemberRes;
 import com.example.weterview.service.MyPageService;
 import com.example.weterview.service.StudyGroupService;
 import jakarta.validation.Valid;
@@ -75,48 +74,53 @@ public class MyPageController {
     // 스터디 그룹 신청 수락
     @PostMapping("/accept/{userId}/{studyGroupId}")
     public ApiResponse<?> acceptJoinStudyGroup(
-            @PathVariable Long userId, @PathVariable String studyGroupId) {
-        myPageService.acceptJoinStudyGroup(userId, studyGroupId);
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long userId, @PathVariable long studyGroupId) {
+        myPageService.acceptJoinStudyGroup(
+                customUserDetails.getUser(), userId, studyGroupId);
         return ApiResponse.success();
     }
-
-    // 스터디 그룹 상세 정보 조회
-    @GetMapping("/detail/{studyGroupId}")
-    public ApiResponse<?> getStudyGroupDetail(@PathVariable String studyGroupId) {
-        return studyGroupService.getStudyGroupDetail(studyGroupId);
-    }
-
-    // 스터디 그룹 신청자 조회
-
-    /// 스터디 그룹 상세 정보에서 자신이 개설한 정보 확인
-    @GetMapping("/applied/list/{studyGroupId}")
-    public ApiResponse<?> getAppliedStudyGroup(@PathVariable String studyGroupId) {
-        return studyGroupService.getAppliedStudyGroup(studyGroupId);
-    }
-
 
     // 스터디 그룹 신청 거절
     @PostMapping("/reject/{userId}/{studyGroupId}")
     public ApiResponse<?> rejectJoinStudyGroup(
-            @PathVariable Long userId, @PathVariable String studyGroupId) {
-        return myPageService.rejectJoinStudyGroup(userId, studyGroupId);
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long userId, @PathVariable Long studyGroupId) {
+        myPageService.refuseJoinStudyGroup(
+                customUserDetails.getUser(), userId, studyGroupId);
+        return ApiResponse.success();
     }
 
-    // 좋아요한 게시글 조회
+    // 내가 좋아요한 게시글 조회
     @GetMapping("/likes/posts")
-    public ApiResponse<?> getLikePost(
-            @RequestHeader("Authorization") String jwt,
-            @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+    public ApiResponse<Page<GetLikedPostRes>> getLikePost(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
-        return myPageService.getLikePost(jwt, pageNumber - 1, pageSize);
+        Page<GetLikedPostRes> response =
+                myPageService.getLikedPosts(customUserDetails.getUser(), pageNumber - 1, pageSize);
+        return ApiResponse.success(response);
     }
 
     // 댓글단 게시글 조회
     @GetMapping("/commented/posts")
-    public ApiResponse<?> getCommentedPost(
-            @RequestHeader("Authorization") String jwt,
-            @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+    public ApiResponse<Page<GetCommentedStudyGroupRes>> getCommentedPost(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
-        return myPageService.getCommentedPost(jwt, pageNumber - 1, pageSize);
+        Page<GetCommentedStudyGroupRes> response =
+                myPageService.getCommentedPosts(customUserDetails.getUser(), pageNumber, pageSize);
+        return ApiResponse.success(response);
+    }
+
+    // 스터디 그룹에 신청한 신청자 목록 조회
+    @GetMapping("/applied/list/{studyGroupId}")
+    public ApiResponse<Page<GetStudyGroupApplyMemberRes>> getAppliedStudyGroup(
+            @PathVariable Long studyGroupId,
+            @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
+            @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
+        Page<GetStudyGroupApplyMemberRes> response =
+                myPageService.getAppliedStudyGroup(studyGroupId, pageNumber - 1, pageSize);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/example/weterview/controller/MyPageController.java
+++ b/src/main/java/com/example/weterview/controller/MyPageController.java
@@ -7,8 +7,10 @@ import com.example.weterview.dto.myPage.response.GetHostedStudyGroupRes;
 import com.example.weterview.dto.myPage.response.MyPageRes;
 import com.example.weterview.service.MyPageService;
 import com.example.weterview.service.StudyGroupService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,7 +29,7 @@ public class MyPageController {
     public ApiResponse<MyPageRes> getMyPageInfo(
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         MyPageRes response = myPageService.getMyPageInfo(customUserDetails.getUser());
-        return ApiResponse.ok(response, "사용자 정보 반환");
+        return ApiResponse.success(response);
     }
 
     // TODO : 추후 S3 적용하여 변경
@@ -38,18 +40,23 @@ public class MyPageController {
 
     // 닉네임 변경
     @PatchMapping("/update/nickname")
-    public ApiResponse<?> updateNickname(@RequestHeader("Authorization") String jwt, @RequestBody UpdateNicknameReq req) {
-        return myPageService.updateNickname(jwt, req);
+    public ApiResponse<?> updateNickname(
+            @RequestBody @Valid UpdateNicknameReq req,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        myPageService.updateNickname(customUserDetails.getUser(), req);
+        return ApiResponse.success();
     }
 
     // 내가 개설한 스터디 그룹 모집 게시글 조회
     @GetMapping("/hosted-study-groups")
-    public ApiResponse<List<GetHostedStudyGroupRes>> getHostedStudyGroups(
-            @RequestHeader("Authorization") String jwt,
-            @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+    public ApiResponse<?> getHostedStudyGroups(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @RequestParam(value = "pageSize", defaultValue = "10") int pageSize
     ) {
-        return myPageService.getHostedStudyGroups(jwt, pageNumber - 1, pageSize);
+        Page<GetHostedStudyGroupRes> response = myPageService.getHostedStudyGroups(
+                customUserDetails.getUser(), pageNumber - 1, pageSize);
+        return ApiResponse.success(response);
     }
 
     // 내가 참여한 스터디 그룹 모집 게시글 조회

--- a/src/main/java/com/example/weterview/controller/MyPageController.java
+++ b/src/main/java/com/example/weterview/controller/MyPageController.java
@@ -4,6 +4,7 @@ import com.example.weterview.config.CustomUserDetails;
 import com.example.weterview.dto.common.ApiResponse;
 import com.example.weterview.dto.myPage.request.UpdateNicknameReq;
 import com.example.weterview.dto.myPage.response.GetHostedStudyGroupRes;
+import com.example.weterview.dto.myPage.response.GetJoinedStudyGroupRes;
 import com.example.weterview.dto.myPage.response.MyPageRes;
 import com.example.weterview.service.MyPageService;
 import com.example.weterview.service.StudyGroupService;
@@ -62,10 +63,12 @@ public class MyPageController {
     // 내가 참여한 스터디 그룹 모집 게시글 조회
     @GetMapping("/joined-study-groups")
     public ApiResponse<?> getJoinedStudyGroups(
-            @RequestHeader("Authorization") String jwt,
-            @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
-        return myPageService.getJoinedStudyGroups(jwt, pageNumber - 1, pageSize);
+        Page<GetJoinedStudyGroupRes> response =
+                myPageService.getJoinedStudyGroups(customUserDetails.getUser(), pageNumber - 1, pageSize);
+        return ApiResponse.success(response);
     }
 
     // 스터디 그룹 상세 정보 조회

--- a/src/main/java/com/example/weterview/controller/MyPageController.java
+++ b/src/main/java/com/example/weterview/controller/MyPageController.java
@@ -71,6 +71,15 @@ public class MyPageController {
         return ApiResponse.success(response);
     }
 
+
+    // 스터디 그룹 신청 수락
+    @PostMapping("/accept/{userId}/{studyGroupId}")
+    public ApiResponse<?> acceptJoinStudyGroup(
+            @PathVariable Long userId, @PathVariable String studyGroupId) {
+        myPageService.acceptJoinStudyGroup(userId, studyGroupId);
+        return ApiResponse.success();
+    }
+
     // 스터디 그룹 상세 정보 조회
     @GetMapping("/detail/{studyGroupId}")
     public ApiResponse<?> getStudyGroupDetail(@PathVariable String studyGroupId) {
@@ -85,12 +94,6 @@ public class MyPageController {
         return studyGroupService.getAppliedStudyGroup(studyGroupId);
     }
 
-    // 스터디 그룹 신청 수락
-    @PostMapping("/accept/{userId}/{studyGroupId}")
-    public ApiResponse<?> acceptJoinStudyGroup(
-            @PathVariable Long userId, @PathVariable String studyGroupId) {
-        return myPageService.acceptJoinStudyGroup(userId, studyGroupId);
-    }
 
     // 스터디 그룹 신청 거절
     @PostMapping("/reject/{userId}/{studyGroupId}")

--- a/src/main/java/com/example/weterview/dto/common/ApiResponse.java
+++ b/src/main/java/com/example/weterview/dto/common/ApiResponse.java
@@ -1,39 +1,54 @@
 package com.example.weterview.dto.common;
 
+import com.example.weterview.enums.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
-
-import javax.swing.text.html.Option;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL) // ⭐️ 핵심: null인 필드는 JSON에 포함되지 않음
 public class ApiResponse<T> {
-    private final int status;
-    private final String message;
+
     private final T data;
+    private final ErrorBody error;
 
-    private ApiResponse(HttpStatus status, String message, T data) {
-        this.status = status.value();
-        this.message = message;
+    // 생성자를 private으로 막고, 정적 팩토리 메서드만 사용하도록 강제
+    private ApiResponse(T data, ErrorBody error) {
         this.data = data;
+        this.error = error;
     }
 
-    public static <T> ApiResponse<T> ok(T data, String message) {
-        return new ApiResponse<>(HttpStatus.OK, message, data);
+    // 1. 성공 응답 (data만 반환)
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(data, null);
     }
 
-    public static <T> ApiResponse<T> ok(String message) {
-        return new ApiResponse<>(HttpStatus.OK, message, null);
+    // 성공이지만 반환할 데이터가 없는 경우 (예: 삭제 성공) -> 빈 객체 {} 라도 주는 게 관례상 좋음
+    public static ApiResponse<?> success() {
+        return new ApiResponse<>(null, null); // data가 null이면 빈 JSON {} 이 되거나, 설정을 통해 data: null로 줄 수 있음.
+        // 보통은 success(null) 보다는 success("ok") 처럼 간단한 문자열이라도 주거나,
+        // 프론트랑 협의해서 빈 data 필드를 줍니다. 여기서는 data: null이 아예 안나오게 됩니다.
     }
 
-    public static <T> ApiResponse<T> NOT_FOUND(T data, String message) {
-        return new ApiResponse<>(HttpStatus.NOT_FOUND, message, data);
+    // 2. 실패 응답 (error만 반환)
+    public static ApiResponse<?> fail(String code, String message) {
+        return new ApiResponse<>(null, new ErrorBody(code, message));
     }
 
-    public static <T> ApiResponse<T> NOT_FOUND(String message) {
-        return new ApiResponse<>(HttpStatus.NOT_FOUND, message, null);
+    public static ApiResponse<?> fail(ErrorCode errorCode) {
+        return new ApiResponse<>(null, new ErrorBody(errorCode.getCode(), errorCode.getMessage()));
     }
 
-    public static <T> ApiResponse<T> BAD_REQUEST(T data, String message) {
-        return new ApiResponse<>(HttpStatus.BAD_REQUEST, message, data);
+    public static ApiResponse<?> fail(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(null, new ErrorBody(errorCode.getCode(), message));
+    }
+
+    // 내부 클래스: 에러 구조 정의
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ErrorBody {
+        private final String code;
+        private final String message;
     }
 }

--- a/src/main/java/com/example/weterview/dto/common/ApiResponse.java
+++ b/src/main/java/com/example/weterview/dto/common/ApiResponse.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Collections;
+
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL) // ⭐️ 핵심: null인 필드는 JSON에 포함되지 않음
 public class ApiResponse<T> {
@@ -24,11 +26,9 @@ public class ApiResponse<T> {
         return new ApiResponse<>(data, null);
     }
 
-    // 성공이지만 반환할 데이터가 없는 경우 (예: 삭제 성공) -> 빈 객체 {} 라도 주는 게 관례상 좋음
+    // 성공이지만 반환할 데이터가 없는 경우 (예: 삭제 성공)
     public static ApiResponse<?> success() {
-        return new ApiResponse<>(null, null); // data가 null이면 빈 JSON {} 이 되거나, 설정을 통해 data: null로 줄 수 있음.
-        // 보통은 success(null) 보다는 success("ok") 처럼 간단한 문자열이라도 주거나,
-        // 프론트랑 협의해서 빈 data 필드를 줍니다. 여기서는 data: null이 아예 안나오게 됩니다.
+        return new ApiResponse<>(Collections.emptyMap(), null);
     }
 
     // 2. 실패 응답 (error만 반환)

--- a/src/main/java/com/example/weterview/dto/studyGroup/response/GetStudyGroupApplyMemberRes.java
+++ b/src/main/java/com/example/weterview/dto/studyGroup/response/GetStudyGroupApplyMemberRes.java
@@ -1,17 +1,33 @@
 package com.example.weterview.dto.studyGroup.response;
 
+import com.example.weterview.dto.myPage.response.GetJoinedStudyGroupRes;
+import com.example.weterview.entity.StudyGroupMember;
 import com.example.weterview.enums.studyMembership.JoinEnum;
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetStudyGroupApplyMemberRes {
     private Long userId;
     private String kakaoUserNumber;
     private String nickname;
     private String kakaoEmail;
     private String gender;
-    private LocalDateTime createdAt;
     private String status;
+
+    public static GetStudyGroupApplyMemberRes from(StudyGroupMember studyGroupMember) {
+        return GetStudyGroupApplyMemberRes.builder()
+                .userId(studyGroupMember.getUser().getId())
+                .kakaoUserNumber(studyGroupMember.getUser().getKakaoUserNumber())
+                .nickname(studyGroupMember.getUser().getNickname())
+                .kakaoEmail(studyGroupMember.getUser().getKakaoEmail())
+                .gender(studyGroupMember.getUser().getGender())
+                .status(String.valueOf(studyGroupMember.getJoin()))
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/weterview/entity/StudyGroup.java
+++ b/src/main/java/com/example/weterview/entity/StudyGroup.java
@@ -1,8 +1,10 @@
 package com.example.weterview.entity;
 
+import com.example.weterview.enums.ErrorCode;
 import com.example.weterview.enums.studyGroup.FieldEnum;
 import com.example.weterview.enums.studyGroup.LocationEnum;
 import com.example.weterview.enums.studyGroup.StatusEnum;
+import com.example.weterview.exception.CustomException;
 import jakarta.persistence.*;
 import lombok.Data;
 import org.hibernate.annotations.Comment;
@@ -92,4 +94,11 @@ public class StudyGroup {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    // 내가 생성한 스터디 그룹 게시글인지 확인
+    public void validateHost(User user) {
+        if (!this.user.getKakaoUserNumber().equals(user.getKakaoUserNumber())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+    }
 }

--- a/src/main/java/com/example/weterview/entity/StudyGroupMember.java
+++ b/src/main/java/com/example/weterview/entity/StudyGroupMember.java
@@ -63,6 +63,12 @@ public class StudyGroupMember {
         this.acceptedAt = LocalDateTime.now();
     }
 
+    public void refuseJoin() {
+        validateStatusForAccept();
+        this.join = JoinEnum.REFUSE;
+        this.refusedAt = LocalDateTime.now();
+    }
+
     // 유효성 검증
     private void validateStatusForAccept() {
         if (this.join == JoinEnum.ACCEPT) {

--- a/src/main/java/com/example/weterview/entity/StudyGroupMember.java
+++ b/src/main/java/com/example/weterview/entity/StudyGroupMember.java
@@ -1,8 +1,10 @@
 package com.example.weterview.entity;
 
+import com.example.weterview.enums.ErrorCode;
 import com.example.weterview.enums.studyMembership.JoinEnum;
+import com.example.weterview.exception.CustomException;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.*;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,7 +13,10 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "study_group_members")
 @Comment("사용자와 스터디 그룹 간의 참가 신청 및 상태(신청/수락/거절)를 관리하는 매핑 테이블")
-@Data
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class StudyGroupMember {
     @Id
@@ -51,4 +56,21 @@ public class StudyGroupMember {
     @Column(name = "refused_at")
     @Comment(value = "거절한 날짜, 시간")
     private LocalDateTime refusedAt;
+
+    public void acceptJoin() {
+        validateStatusForAccept();
+        this.join = JoinEnum.ACCEPT;
+        this.acceptedAt = LocalDateTime.now();
+    }
+
+    // 유효성 검증
+    private void validateStatusForAccept() {
+        if (this.join == JoinEnum.ACCEPT) {
+            throw new CustomException(ErrorCode.ALREADY_ACCEPTED_MEMBER);
+        }
+
+        if(this.join == JoinEnum.REFUSE) {
+            throw new CustomException(ErrorCode.ALREADY_REFUSED_MEMBER);
+        }
+    }
 }

--- a/src/main/java/com/example/weterview/entity/User.java
+++ b/src/main/java/com/example/weterview/entity/User.java
@@ -9,10 +9,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Data
 @Table(name = "users")
 @EntityListeners(AuditingEntityListener.class)
-
+@Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -44,4 +43,8 @@ public class User {
     @Column(name = "updated_at")
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
 }

--- a/src/main/java/com/example/weterview/enums/ErrorCode.java
+++ b/src/main/java/com/example/weterview/enums/ErrorCode.java
@@ -23,7 +23,12 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "USER_400", "이미 존재하는 닉네임입니다."),
 
     // StudyGroup
-    STUDY_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_404", "존재하지 않는 스터디 그룹입니다.");
+    STUDY_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_404", "존재하지 않는 스터디 그룹입니다."),
+
+    // StudyGroupMember
+    ALREADY_ACCEPTED_MEMBER(HttpStatus.CONFLICT, "STUDY_MEMBER_409", "이미 수락된 스터디 그룹원입니다."),
+    ALREADY_REFUSED_MEMBER(HttpStatus.CONFLICT, "STUDY_MEMBER_409_2", "이미 거절된 스터디 그룹원입니다. 재신청이 필요합니다."),
+    STUDY_GROUP_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_MEMBER_404", "스터디 그룹에 신청한 이력이 없습니다"),;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/weterview/enums/ErrorCode.java
+++ b/src/main/java/com/example/weterview/enums/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.example.weterview.enums;
+package com.example.weterview.dto.common;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,25 +7,25 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    // 400 BAD_REQUEST
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
-    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "파라미터가 유효하지 않습니다."),
-    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
 
-    // 401 UNAUTHORIZED
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    // Global
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_500", "서버 내부 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "GLOBAL_400", "입력값이 올바르지 않습니다."),
 
-    // 403 FORBIDDEN
-    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 리소스에 접근할 권한이 없습니다"),
+    // FORBIDDEN
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_403", "해당 리소스에 접근 권한이 없습니다"),
 
-    // 404 NOT_FOUND
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-    STUDY_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 그룹입니다."),
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_401", "인증되지 않은 사용자입니다."),
 
-    // 500 INTERNAL_SERVER_ERROR
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404", "존재하지 않는 사용자입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "USER_400", "이미 존재하는 닉네임입니다."),
+
+    // StudyGroup
+    STUDY_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_404", "존재하지 않는 스터디 그룹입니다.");
 
     private final HttpStatus httpStatus;
+    private final String code;
     private final String message;
 }

--- a/src/main/java/com/example/weterview/enums/ErrorCode.java
+++ b/src/main/java/com/example/weterview/enums/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.example.weterview.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // 400 BAD_REQUEST
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "파라미터가 유효하지 않습니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+
+    // 401 UNAUTHORIZED
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+    // 403 FORBIDDEN
+    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 리소스에 접근할 권한이 없습니다"),
+
+    // 404 NOT_FOUND
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    STUDY_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 그룹입니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+
+    // 500 INTERNAL_SERVER_ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/weterview/enums/ErrorCode.java
+++ b/src/main/java/com/example/weterview/enums/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.example.weterview.dto.common;
+package com.example.weterview.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/weterview/exception/CustomException.java
+++ b/src/main/java/com/example/weterview/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.example.weterview.exception;
+
+import com.example.weterview.enums.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/example/weterview/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/weterview/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.example.weterview.exception;
+
+import com.example.weterview.dto.common.ApiResponse;
+import com.example.weterview.enums.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 로직 예외 (CustomException)
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+        log.warn("CustomException: {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.fail(e.getErrorCode()));
+    }
+
+    // @Valid 유효성 검사 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+        String errorMessage = bindingResult.getAllErrors().get(0).getDefaultMessage();
+
+        log.warn("Validation Failed: {}", errorMessage);
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, errorMessage));
+    }
+
+    // 그 외 예상치 못한 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("Unhandled Exception: ", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/example/weterview/repository/StudyGroupCommentRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupCommentRepository.java
@@ -6,6 +6,8 @@ import com.example.weterview.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,5 +16,10 @@ import java.util.List;
 public interface StudyGroupCommentRepository extends JpaRepository<StudyGroupComment,Long> {
     List<StudyGroupComment> findByStudyGroupId(Long studyGroup_id);
 
-    Page<StudyGroupComment> findStudyGroupCommentsByUser(User user, Pageable pageable);
+    @Query(value = "select sgc " +
+            "from StudyGroupComment sgc " +
+            "join fetch sgc.studyGroup " +
+            "where sgc.user = :user",
+            countQuery = "select count(sgc) from StudyGroupComment sgc where sgc.user = :user")
+    Page<StudyGroupComment> findByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/example/weterview/repository/StudyGroupLikeRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupLikeRepository.java
@@ -1,12 +1,13 @@
 package com.example.weterview.repository;
 
-import com.example.weterview.dto.myPage.response.GetLikedPostRes;
 import com.example.weterview.entity.StudyGroup;
 import com.example.weterview.entity.StudyGroupLike;
 import com.example.weterview.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -15,5 +16,10 @@ import java.util.Optional;
 public interface StudyGroupLikeRepository extends JpaRepository<StudyGroupLike, Long> {
     Optional<StudyGroupLike> findByStudyGroupAndUser(StudyGroup studyGroup, User user);
 
-    Page<StudyGroupLike> findByUserAndIsLiked(User user, boolean isLiked, Pageable pageable);
+    @Query(value = "select sgl " +
+            "from StudyGroupLike sgl " +
+            "join fetch sgl.studyGroup " +
+            "where sgl.user = :user",
+    countQuery = "select sgl from StudyGroupLike sgl where sgl.user = :user")
+    Page<StudyGroupLike> findByUserAndIsLiked(@Param("user") User user, boolean isLiked, Pageable pageable);
 }

--- a/src/main/java/com/example/weterview/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupMemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,10 +17,19 @@ import java.util.Optional;
 public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMember, Long> {
     Optional<StudyGroupMember> findStudyGroupMemberByUser(User user);
 
-    Optional<List<StudyGroupMember>> findStudyGroupMembersListByStudyGroup(StudyGroup studyGroup);
+    @Query(value = "select sgm " +
+            "from StudyGroupMember sgm " +
+            "join fetch User u " +
+            "where sgm.studyGroup.id = :studyGroupId",
+    countQuery = "select count(*) from StudyGroupMember sgm where sgm.studyGroup.id = :studyGroupId")
+    Page<StudyGroupMember> findByStudyGroup(@Param("studyGroupId") Long studyGroupId, Pageable pageable);
 
     Optional<StudyGroupMember> findByUserIdAndStudyGroupId(Long userId, StudyGroup studyGroup);
 
-    @Query("select sgm, sg from StudyGroupMember sgm left join StudyGroup sg on sgm.studyGroup.id = sg.id")
-    Page<StudyGroupMember> findStudyGroupMembersByUser(User user, Pageable pageable);
+    @Query(value = "select sgm " +
+            "from StudyGroupMember sgm " +
+            "join fetch sgm.studyGroup " +
+            "where sgm.user = :user",
+    countQuery = "select count(sgm) from StudyGroupMember sgm where sgm.user = :user")
+    Page<StudyGroupMember> findByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/example/weterview/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupMemberRepository.java
@@ -18,7 +18,7 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
 
     Optional<List<StudyGroupMember>> findStudyGroupMembersListByStudyGroup(StudyGroup studyGroup);
 
-    Optional<StudyGroupMember> findStudyGroupMemberByUserAndStudyGroup(User user, StudyGroup studyGroup);
+    Optional<StudyGroupMember> findByUserIdAndStudyGroupId(Long userId, StudyGroup studyGroup);
 
     @Query("select sgm, sg from StudyGroupMember sgm left join StudyGroup sg on sgm.studyGroup.id = sg.id")
     Page<StudyGroupMember> findStudyGroupMembersByUser(User user, Pageable pageable);

--- a/src/main/java/com/example/weterview/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupMemberRepository.java
@@ -6,6 +6,7 @@ import com.example.weterview.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,5 +20,6 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
 
     Optional<StudyGroupMember> findStudyGroupMemberByUserAndStudyGroup(User user, StudyGroup studyGroup);
 
+    @Query("select sgm, sg from StudyGroupMember sgm left join StudyGroup sg on sgm.studyGroup.id = sg.id")
     Page<StudyGroupMember> findStudyGroupMembersByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/example/weterview/repository/StudyGroupRepository.java
+++ b/src/main/java/com/example/weterview/repository/StudyGroupRepository.java
@@ -17,13 +17,6 @@ import java.util.Optional;
 public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>,
         JpaSpecificationExecutor<StudyGroup> {
     Page<StudyGroup> findByUser(User user, Pageable pageable);
-    // Users 엔티티에서 kakaonum으로 user id 조회
-    // studygroupmembership에서 user id로 조회
-    // 조회한 게시글 id로 studygroup에서 조회
-
-    // 인기 스터디 게시글 조회
-    @Query("SELECT sg FROM StudyGroup sg WHERE sg.id IN (SELECT s.studyGroup.id FROM StudyMembership s WHERE s.user.id = (SELECT u.id FROM User u WHERE u.kakaoUserNumber = :kakaoNum))")
-    Page<StudyGroup> findByKakaonum(@Param("kakaoNum") String kakaoNum, Pageable pageable);
 
     @Query("SELECT s FROM StudyGroup s " +
             "LEFT JOIN StudyGroupMember m ON s.id = m.studyGroup.id " +

--- a/src/main/java/com/example/weterview/service/MyPageService.java
+++ b/src/main/java/com/example/weterview/service/MyPageService.java
@@ -1,10 +1,13 @@
 package com.example.weterview.service;
 
+import com.example.weterview.config.CustomUserDetails;
 import com.example.weterview.dto.common.ApiResponse;
 import com.example.weterview.dto.myPage.request.UpdateNicknameReq;
 import com.example.weterview.dto.myPage.response.*;
 import com.example.weterview.entity.*;
+import com.example.weterview.enums.ErrorCode;
 import com.example.weterview.enums.studyMembership.JoinEnum;
+import com.example.weterview.exception.CustomException;
 import com.example.weterview.repository.*;
 import com.example.weterview.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,6 +25,7 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MyPageService {
     private final UserRepository userRepository;
     private final StudyGroupRepository studyGroupRepository;
@@ -35,30 +40,35 @@ public class MyPageService {
     }
 
     // 닉네임 변경
-    public ApiResponse<?> updateNickname(String jwt, UpdateNicknameReq req) {
-        String kakaoUniqueNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
-        User user = userRepository.findByKakaoUserNumber(kakaoUniqueNumber)
-                .orElseThrow(() -> new IllegalArgumentException("없는 사용자 입니다"));
+    @Transactional
+    public void updateNickname(User principalUser, UpdateNicknameReq req) {
+        String newNickname = req.getNickname();
 
-        user.setNickname(req.getNickname());
+        // 닉네임 중복 검증
+        if (userRepository.existsByNickname(newNickname)) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
 
-        userRepository.save(user);
+        // 영속성 컨텐스트 안으로 엔티티 가져오기
+        // principalUser는 SecurityFilter가 만든 준영속 객체이다
+        User user = userRepository.findById(principalUser.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        return ApiResponse.ok(null, "닉네임 변경 성공");
+        // user는 영속 상태
+        // 값 변경 시에 트랜잭션 종료 시 알아서 update 쿼리가 나간다.
+        user.changeNickname(newNickname);
     }
 
     // 내가 개설한 스터디 그룹 모집 게시글 조회
-    public ApiResponse<List<GetHostedStudyGroupRes>> getHostedStudyGroups(
-            String jwt, int pageNumber, int pageSize) {
-        String kakaoUniqueNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
-
+    public Page<GetHostedStudyGroupRes> getHostedStudyGroups(
+            User principalUser, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize,
                 Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<StudyGroup> hostedStudyGroupPage = studyGroupRepository.findByKakaonum(kakaoUniqueNumber, pageable);
+
+        Page<StudyGroup> hostedStudyGroupPage = studyGroupRepository.findByUser(principalUser, pageable);
 
         // 정적 팩토리 메서드 방식
-        Page<GetHostedStudyGroupRes> result = hostedStudyGroupPage.map(GetHostedStudyGroupRes::from);
-        return ApiResponse.ok(result.getContent(), "자신이 개설한 스터디 그룹 조회");
+        return hostedStudyGroupPage.map(GetHostedStudyGroupRes::from);
     }
 
     // 내가 참여한 스터디 그룹 모집 게시글 조회
@@ -77,6 +87,7 @@ public class MyPageService {
     };
 
     /// 스터디 그룹 신청 수락
+    @Transactional
     public ApiResponse<?> acceptJoinStudyGroup(Long userId, String studyGroupId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다"));
@@ -96,6 +107,7 @@ public class MyPageService {
     }
 
     /// 스터디 그룹 신청 거절
+    @Transactional
     public ApiResponse<?> rejectJoinStudyGroup(Long userId, String studyGroupId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다"));

--- a/src/main/java/com/example/weterview/service/MyPageService.java
+++ b/src/main/java/com/example/weterview/service/MyPageService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -87,15 +88,15 @@ public class MyPageService {
 
     /// 스터디 그룹 신청 수락
     @Transactional
-    public void acceptJoinStudyGroup(Long userId, String studyGroupId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        StudyGroup studyGroup = studyGroupRepository.findById(Long.parseLong(studyGroupId))
+    public void acceptJoinStudyGroup(User principalUser, Long userId, long studyGroupId) {
+        StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STUDY_GROUP_NOT_FOUND));
+
+        studyGroup.validateHost(principalUser);
 
         // 영속 객체
         StudyGroupMember studyGroupMember =
-                studyGroupMemberRepository.findStudyGroupMemberByUserAndStudyGroup(user, studyGroup)
+                studyGroupMemberRepository.findByUserIdAndStudyGroupId(userId, studyGroup)
                         .orElseThrow(() -> new CustomException(ErrorCode.STUDY_GROUP_MEMBER_NOT_FOUND));
 
         studyGroupMember.acceptJoin();

--- a/src/main/java/com/example/weterview/service/MyPageService.java
+++ b/src/main/java/com/example/weterview/service/MyPageService.java
@@ -87,22 +87,18 @@ public class MyPageService {
 
     /// 스터디 그룹 신청 수락
     @Transactional
-    public ApiResponse<?> acceptJoinStudyGroup(Long userId, String studyGroupId) {
+    public void acceptJoinStudyGroup(Long userId, String studyGroupId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다"));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         StudyGroup studyGroup = studyGroupRepository.findById(Long.parseLong(studyGroupId))
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디 그룹 ID 입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDY_GROUP_NOT_FOUND));
 
+        // 영속 객체
         StudyGroupMember studyGroupMember =
                 studyGroupMemberRepository.findStudyGroupMemberByUserAndStudyGroup(user, studyGroup)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않습니다"));
+                        .orElseThrow(() -> new CustomException(ErrorCode.STUDY_GROUP_MEMBER_NOT_FOUND));
 
-        studyGroupMember.setJoin(JoinEnum.ACCEPT);
-        studyGroupMember.setAcceptedAt(LocalDateTime.now());
-
-        studyGroupMemberRepository.save(studyGroupMember);
-
-        return ApiResponse.ok("승인했습니다.");
+        studyGroupMember.acceptJoin();
     }
 
     /// 스터디 그룹 신청 거절

--- a/src/main/java/com/example/weterview/service/MyPageService.java
+++ b/src/main/java/com/example/weterview/service/MyPageService.java
@@ -4,6 +4,7 @@ import com.example.weterview.config.CustomUserDetails;
 import com.example.weterview.dto.common.ApiResponse;
 import com.example.weterview.dto.myPage.request.UpdateNicknameReq;
 import com.example.weterview.dto.myPage.response.*;
+import com.example.weterview.dto.studyGroup.response.GetStudyGroupApplyMemberRes;
 import com.example.weterview.entity.*;
 import com.example.weterview.enums.ErrorCode;
 import com.example.weterview.enums.studyMembership.JoinEnum;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -79,11 +81,9 @@ public class MyPageService {
                 Sort.by(Sort.Direction.DESC, "appliedAt"));
 
         Page<StudyGroupMember> members =
-                studyGroupMemberRepository.findStudyGroupMembersByUser(principalUser, pageable);
+                studyGroupMemberRepository.findByUser(principalUser, pageable);
 
-        Page<GetJoinedStudyGroupRes> result = members.map(GetJoinedStudyGroupRes::from);
-
-        return result;
+        return members.map(GetJoinedStudyGroupRes::from);
     };
 
     /// 스터디 그룹 신청 수락
@@ -104,55 +104,47 @@ public class MyPageService {
 
     /// 스터디 그룹 신청 거절
     @Transactional
-    public ApiResponse<?> rejectJoinStudyGroup(Long userId, String studyGroupId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다"));
-        StudyGroup studyGroup = studyGroupRepository.findById(Long.parseLong(studyGroupId))
+    public void refuseJoinStudyGroup(User principalUser, Long userId, Long studyGroupId) {
+        StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디 그룹 ID 입니다."));
 
+        studyGroup.validateHost(principalUser);
+
         StudyGroupMember studyGroupMember =
-                studyGroupMemberRepository.findStudyGroupMemberByUserAndStudyGroup(user, studyGroup)
+                studyGroupMemberRepository.findByUserIdAndStudyGroupId(userId, studyGroup)
                         .orElseThrow(() -> new IllegalArgumentException("존재하지 않습니다"));
-
-        studyGroupMember.setJoin(JoinEnum.REFUSE);
-        studyGroupMember.setRefusedAt(LocalDateTime.now());
-
-        studyGroupMemberRepository.save(studyGroupMember);
-
-        return ApiResponse.ok("거절했습니다");
+        studyGroupMember.refuseJoin();
     }
 
-    // 내가 좋아요한 게시글
-    public ApiResponse<?> getLikePost(String jwt, int pageNumber, int pageSize) {
-        String kakaoUserNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
-        User user = userRepository.findByKakaoUserNumber(kakaoUserNumber)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다"));
-
+    // 내가 좋아요한 게시글 조회
+    public Page<GetLikedPostRes> getLikedPosts(User principalUser, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize,
                 Sort.by(Sort.Direction.DESC, "createdAt"));
 
         Page<StudyGroupLike> studyGroupLikes =
-                studyGroupLikeRepository.findByUserAndIsLiked(user, true, pageable);
+                studyGroupLikeRepository.findByUserAndIsLiked(principalUser, true, pageable);
 
-        Page<GetLikedPostRes> result = studyGroupLikes.map(GetLikedPostRes::from);
-
-        return ApiResponse.ok(result, "success");
+        return studyGroupLikes.map(GetLikedPostRes::from);
     }
 
     // 댓글단 게시글 조회
-    public ApiResponse<Page<GetCommentedStudyGroupRes>> getCommentedPost(String jwt, int pageNumber, int pageSize) {
-        String kakaoUserNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
-        User user = userRepository.findByKakaoUserNumber(kakaoUserNumber)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다"));
-
+    public Page<GetCommentedStudyGroupRes> getCommentedPosts(User principalUser, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize,
                 Sort.by(Sort.Direction.DESC, "createdAt"));
 
         Page<StudyGroupComment> studyGroupComments =
-                studyGroupCommentRepository.findStudyGroupCommentsByUser(user, pageable);
+                studyGroupCommentRepository.findByUser(principalUser, pageable);
 
-        Page<GetCommentedStudyGroupRes> result = studyGroupComments.map(GetCommentedStudyGroupRes::from);
+        return studyGroupComments.map(GetCommentedStudyGroupRes::from);
+    }
 
-        return ApiResponse.ok(result, "success");
+    // 스터디 그룹에 신청한 신청자 목록 조회
+    public Page<GetStudyGroupApplyMemberRes> getAppliedStudyGroup(Long studyGroupId, int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(
+                pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        Page<StudyGroupMember> member =
+                studyGroupMemberRepository.findByStudyGroup(studyGroupId, pageable);
+
+        return member.map(GetStudyGroupApplyMemberRes::from);
     }
 }

--- a/src/main/java/com/example/weterview/service/MyPageService.java
+++ b/src/main/java/com/example/weterview/service/MyPageService.java
@@ -72,18 +72,17 @@ public class MyPageService {
     }
 
     // 내가 참여한 스터디 그룹 모집 게시글 조회
-    public ApiResponse<Page<GetJoinedStudyGroupRes>> getJoinedStudyGroups(String jwt, int pageNumber, int pageSize) {
-        String kakaoUniqueNumber = jwtUtil.getKakaoUserNumFromToken(jwt);
-        User user = userRepository.findByKakaoUserNumber(kakaoUniqueNumber)
-                .orElseThrow(() -> new IllegalArgumentException("없는 사용자 입니다"));
-
+    public Page<GetJoinedStudyGroupRes> getJoinedStudyGroups(
+            User principalUser, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize,
                 Sort.by(Sort.Direction.DESC, "appliedAt"));
 
-        Page<StudyGroupMember> members = studyGroupMemberRepository.findStudyGroupMembersByUser(user, pageable);
+        Page<StudyGroupMember> members =
+                studyGroupMemberRepository.findStudyGroupMembersByUser(principalUser, pageable);
 
         Page<GetJoinedStudyGroupRes> result = members.map(GetJoinedStudyGroupRes::from);
-        return ApiResponse.ok(result, "자신이 참여한 스터디 그룹 조회");
+
+        return result;
     };
 
     /// 스터디 그룹 신청 수락

--- a/src/main/java/com/example/weterview/service/StudyGroupService.java
+++ b/src/main/java/com/example/weterview/service/StudyGroupService.java
@@ -353,30 +353,6 @@ public class StudyGroupService {
         return ApiResponse.ok(result, "Success");
     }
 
-    public ApiResponse<List<GetStudyGroupApplyMemberRes>> getAppliedStudyGroup(String studyGroupId) {
-        StudyGroup studyGroup = studyGroupRepository.findById(Long.parseLong(studyGroupId))
-                .orElseThrow(() -> new IllegalArgumentException(studyGroupId + "에 해당하는 게시글이 없습니다."));
-        List<StudyGroupMember> studyGroupMembers =
-                studyGroupMemberRepository.findStudyGroupMembersListByStudyGroup(studyGroup)
-                        .orElseThrow(() -> new IllegalArgumentException(studyGroup.getId() + "에 신청/참여한 사용자가 없습니다."));
-
-        List<GetStudyGroupApplyMemberRes> applyMemberList = new ArrayList<>();
-        for (int i = 0; i < studyGroupMembers.size(); i++) {
-            GetStudyGroupApplyMemberRes applyMember = new GetStudyGroupApplyMemberRes();
-            applyMember.setUserId(studyGroupMembers.get(i).getUser().getId());
-            applyMember.setNickname(studyGroupMembers.get(i).getUser().getNickname());
-            applyMember.setGender(studyGroupMembers.get(i).getUser().getGender());
-            applyMember.setKakaoEmail(studyGroupMembers.get(i).getUser().getKakaoEmail());
-            applyMember.setKakaoUserNumber(studyGroupMembers.get(i).getUser().getKakaoUserNumber());
-            applyMember.setCreatedAt(studyGroupMembers.get(i).getUser().getCreatedAt());
-            applyMember.setStatus(studyGroupMembers.get(i).getJoin().toString());
-
-            applyMemberList.add(applyMember);
-        }
-
-        return ApiResponse.ok(applyMemberList, studyGroupId + "에 신청한 사용자 정보 목록입니다.");
-    }
-
     public Pageable createPageable(GetStudyGroupReq req) {
         return PageRequest.of(
                 req.getPageNumber() - 1,


### PR DESCRIPTION
### 기존
- api 별로 예외처리 메시지 제각각
- 책임 분리 안되어 있음
- 절차지향적 코드

### 개선
- 추가 : 전역 예외처리 handler 추가
   - 서비스 레이어에서 예외를 던지면 전역 예외처리 handler가 예외를 받아서 일관된 응답으로 내려준다
   - 성공이면 data  실패면 code, message 반환
   - 성공 시에 응답할 데이터가 없는 경우에는 빈 객체 반환
- 개선
   - 서비스 레이어에서는 로직 순서를 관리
   - entity, dto에서는 로직 수행 