### PR TITLE
[FIX] github action이 빌드 할 때 dev-secret.yml 제외하고 빌드하게 되는 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,22 +34,6 @@ jobs:
           chmod +x ./gradlew
           ./gradlew build -x test
 
-      - name: Debug - Check JAR content
-        run: |
-          echo "=========================================="
-          echo "Checking file existence before build..."
-          ls -al ./src/main/resources/dev-secret.yml
-          
-          echo "------------------------------------------"
-          echo "Checking built JAR file name..."
-          ls -al build/libs/
-          
-          echo "------------------------------------------"
-          echo "Looking for dev-secret.yml inside the JAR..."
-          
-          jar tf build/libs/*SNAPSHOT.jar | grep dev-secret.yml
-          echo "=========================================="
-
       # Docker Hub 접속
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,6 @@ tasks.named('jar') {
 }
 
 // 빌드할 때 제외
-bootJar {
-	rootSpec.exclude("**/dev-secret.yml")
-}
+//bootJar {
+//	rootSpec.exclude("**/dev-secret.yml")
+//}


### PR DESCRIPTION
## 문제발생
dockerfile, deploy.yml과 github action을 사용해서 ci/cd 파이프라인 구축 중에 docker container 로그 조회 시에

<img width="1242" height="201" alt="스크린샷 2025-12-30 13 00 57" src="https://github.com/user-attachments/assets/35baff1f-985a-4fbb-a86b-9c10434d002b" />
사진과 같은 에러 로그 발생

docker hub에 올린 이미지를 EC2에서 pull 받아 서버 배포하게 되는데 이때 dev-secret이 없다는 문제

## 원인분석
- deploy.yml 스크립트 코드 분석
  - 프로젝트 코드 빌드 시에 dev-secrey.yml이 생성 되는지 확인
  - JAR 파일 내에 dev-secret.yml이 있는지 확인 **(원인)**
- dockerfile 분석
  - COPY build/libs/*.jar app.jar 
  - spring boot 프로젝트를 빌드하게 되면  plain.jar(패키지, 라이브라리 없는 JAR), -.jar 2개의 JAR 파일이 생긴다. docker는 Dockerfile(지시서)로 이미지를 만들어 dockerhub에 push 하게 되는데 이 때 dockerfile에는 plain.jar를 참조하게 된다. 

## 해결
프로젝트에 dev-secret.yml 파일이 생성되지만 build.gradle에
`bootJar {
	rootSpec.exclude("**/dev-secret.yml")
}`
이 설정 때문에 빌드 시에 dev-secret.yml이 포함안되던 것이 었기 때문에 주석 처리